### PR TITLE
Bug: Fixed bug with equal button.

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -59,7 +59,7 @@ $(document).ready(function(){
 	})
 
 	$(".equal").click(function() {
-		getResult(operations[1]);
+		getResult(operations[operations.length - 1]);
 	})
 })
 


### PR DESCRIPTION
Equal button now calls getResult with the last element in operations instead of element at index 1.
Calling index 1 all the time will not give any result unless calculations are chained.
The called element is changed from 1 to the last element.
